### PR TITLE
fix: ensure single res.end in request handlers

### DIFF
--- a/pages/api/applicants/[period-id]/[id].ts
+++ b/pages/api/applicants/[period-id]/[id].ts
@@ -58,7 +58,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 
   res.setHeader("Allow", ["GET", "DELETE"]);
-  res.status(405).end(`Method ${req.method} is not allowed.`);
+  return res.status(405).end(`Method ${req.method} is not allowed.`);
 };
 
 export default handler;

--- a/pages/api/applicants/[period-id]/index.ts
+++ b/pages/api/applicants/[period-id]/index.ts
@@ -33,7 +33,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 
   res.setHeader("Allow", ["GET"]);
-  res.status(405).end(`Method ${req.method} is not allowed.`);
+  return res.status(405).end(`Method ${req.method} is not allowed.`);
 };
 
 export default handler;

--- a/pages/api/applicants/index.ts
+++ b/pages/api/applicants/index.ts
@@ -64,13 +64,13 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     }
   } catch (error) {
     if (error instanceof Error) {
-      res.status(500).json({ error: error.message });
+      return res.status(500).json({ error: error.message });
     }
-    res.status(500).json("An unexpected error occurred");
+    return res.status(500).json("An unexpected error occurred");
   }
 
   res.setHeader("Allow", ["GET", "POST"]);
-  res.status(405).end(`Method ${req.method} is not allowed.`);
+  return res.status(405).end(`Method ${req.method} is not allowed.`);
 };
 
 export default handler;

--- a/pages/api/committees/applicants/[period-id]/[committee].ts
+++ b/pages/api/committees/applicants/[period-id]/[committee].ts
@@ -47,7 +47,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 
   res.setHeader("Allow", ["GET"]);
-  res.status(405).end(`Method ${req.method} is not allowed.`);
+  return res.status(405).end(`Method ${req.method} is not allowed.`);
 };
 
 export default handler;

--- a/pages/api/committees/times/[period-id]/[committee].ts
+++ b/pages/api/committees/times/[period-id]/[committee].ts
@@ -71,7 +71,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 
   res.setHeader("Allow", ["GET", "DELETE"]);
-  res.status(405).end(`Method ${req.method} is not allowed.`);
+  return res.status(405).end(`Method ${req.method} is not allowed.`);
 };
 
 export default handler;

--- a/pages/api/committees/times/[period-id]/index.ts
+++ b/pages/api/committees/times/[period-id]/index.ts
@@ -58,7 +58,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 
   res.setHeader("Allow", ["POST"]);
-  res.status(405).end(`Method ${req.method} is not allowed.`);
+  return res.status(405).end(`Method ${req.method} is not allowed.`);
 };
 
 export default handler;

--- a/pages/api/periods/[id].ts
+++ b/pages/api/periods/[id].ts
@@ -29,7 +29,8 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
 
       return res.status(200).json({ exists, period });
     } else if (req.method === "DELETE") {
-      if (!isAdmin(res, session)) return res.status(403).json({ error: "Unauthorized" });
+      if (!isAdmin(res, session))
+        return res.status(403).json({ error: "Unauthorized" });
 
       const { error } = await deletePeriodById(id);
       if (error) throw new Error(error);
@@ -43,7 +44,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 
   res.setHeader("Allow", ["GET", "DELETE"]);
-  res.status(405).end(`Method ${req.method} Not Allowed`);
+  return res.status(405).end(`Method ${req.method} Not Allowed`);
 };
 
 export default handler;

--- a/pages/api/periods/index.ts
+++ b/pages/api/periods/index.ts
@@ -33,11 +33,11 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
       return res.status(201).json({ message: "Period created successfully" });
     }
   } catch {
-    res.status(500).json("An error occurred");
+    return res.status(500).json("An error occurred");
   }
 
   res.setHeader("Allow", ["GET", "POST"]);
-  res.status(405).end(`Method ${req.method} is not allowed.`);
+  return res.status(405).end(`Method ${req.method} is not allowed.`);
 };
 
 export default handler;

--- a/pages/api/periods/ow-committees.ts
+++ b/pages/api/periods/ow-committees.ts
@@ -75,7 +75,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     return res.status(200).json(groups);
   } catch (error) {
     console.error(error);
-    res.status(500).json({ error: "An error occurred" });
+    return res.status(500).json({ error: "An error occurred" });
   }
 };
 

--- a/pages/api/periods/send-interview-times/[period-id].ts
+++ b/pages/api/periods/send-interview-times/[period-id].ts
@@ -34,7 +34,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 
   res.setHeader("Allow", ["POST"]);
-  res.status(405).end(`Method ${req.method} is not allowed.`);
+  return res.status(405).end(`Method ${req.method} is not allowed.`);
 };
 
 export default handler;


### PR DESCRIPTION
Passer på at man ikke sender to responses, da dette gir en feilmelding.
Se f. eks https://stackoverflow.com/questions/60714212/error-err-stream-write-after-end-write-after-end
